### PR TITLE
PENG-3032 Switch to real time history endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ go-newrelic-plugin CHANGELOG
 
 This file is used to list changes made in each version of go-newrelic-plugin.
 
+# 1.6.3
+Zac Audette - Switch to real time history endpoint
+
 # 1.6.2
 Zac Audette - Added Fastly cache miss to New Relic metrics
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,6 @@ node {
         --x-kubernetes-api-user=\"not used\" \
         --x-kubernetes-api-token=\"not used\" \
         --slack-webhook=\"${SLACK_URL}\" \
-        --branch=\"${env.BRANCH_NAME}\" \
         --artifactory-key=\"${PASS_API_ART_KEY}\" \
         --aws-access-key-id=\"${CONFIGS_ACCESS_KEY}\" \
         --aws-secret-access-key=\"${CONFIGS_SECRET_KEY}\" \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,8 +31,6 @@ node {
         --x-kubernetes-api-token=\"not used\" \
         --slack-webhook=\"${SLACK_URL}\" \
         --artifactory-key=\"${PASS_API_ART_KEY}\" \
-        --aws-access-key-id=\"${CONFIGS_ACCESS_KEY}\" \
-        --aws-secret-access-key=\"${CONFIGS_SECRET_KEY}\" \
         --environment=\"${environment}\" \
         --region=\"${region}\" \
         --ci-job-number=${env.BUILD_ID} \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ node {
     string(credentialsId: "PASS_API_ART_KEY", variable: "PASS_API_ART_KEY"),
     string(credentialsId: "CONFIGS_ACCESS_KEY", variable: "CONFIGS_ACCESS_KEY"),
     string(credentialsId: "CONFIGS_SECRET_KEY", variable: "CONFIGS_SECRET_KEY"),
+    string(credentialsId: "NEWRELIC_LICENSE_KEY", variable: "NEWRELIC_LICENSE_KEY"),
     string(credentialsId: "CODECOV_GO_NEWRELIC_PLUGIN", variable: "CODECOV_GO_NEWRELIC_PLUGIN"),
     string(credentialsId: "PAAS_API_CI_VAULT_TOKEN", variable: "PAAS_API_CI_VAULT_TOKEN")
   ]) {
@@ -41,6 +42,7 @@ node {
         --skip-swagger \
         --skip-source-check \
         --skip-validate \
+        --newrelic-license=\"${NEWRELIC_LICENSE_KEY}\" \
         --codecov-token=\"${CODECOV_GO_NEWRELIC_PLUGIN}\""
     }
     catch (err) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ node {
     string(credentialsId: "CONFIGS_ACCESS_KEY", variable: "CONFIGS_ACCESS_KEY"),
     string(credentialsId: "CONFIGS_SECRET_KEY", variable: "CONFIGS_SECRET_KEY"),
     string(credentialsId: "CODECOV_GO_NEWRELIC_PLUGIN", variable: "CODECOV_GO_NEWRELIC_PLUGIN"),
+    string(credentialsId: "PAAS_API_CI_VAULT_TOKEN", variable: "PAAS_API_CI_VAULT_TOKEN")
   ]) {
     try {
 
@@ -18,11 +19,13 @@ node {
       def repo = "GannettDigital/go-newrelic-plugin"
       def environment = "staging"
       def region = "us-east-1"
+      def vaultURL = "https://vault.service.us-east-1.gciconsul.com:8200"
+      def vaultConfig = "/secret/paas-api/paas-api-ci"
 
       print 'Running docker run'
 
 
-      sh "docker run -e \"GIT_BRANCH=${env.BRANCH_NAME}\" --rm -v ~/.docker/config.json:/root/.docker/config.json -v /var/run/docker.sock:/var/run/docker.sock paas-docker-artifactory.gannettdigital.com/paas-api-ci:${paasApiCiVersion} build \
+      sh "docker run -e \"GIT_BRANCH=${env.BRANCH_NAME}\" -e \"VAULT_ADDR=${vaultURL}\" -e \"VAULT_CONFIG_LOCATION=${vaultConfig}\" -e \"VAULT_TOKEN=${PAAS_API_CI_VAULT_TOKEN}\" --rm -v ~/.docker/config.json:/root/.docker/config.json -v /var/run/docker.sock:/var/run/docker.sock paas-docker-artifactory.gannettdigital.com/paas-api-ci:${paasApiCiVersion} build \
         --repo=\"${repo}\" \
         --x-api-key=\"${X_API_KEY}\" \
         --x-scalr-access-key=\"${SCALR_KEY}\" \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ node {
   ]) {
     try {
 
-      def paasApiCiVersion = "3.32.1-113"
+      def paasApiCiVersion = "5.9.4-169"
       def repo = "GannettDigital/go-newrelic-plugin"
       def environment = "staging"
       def region = "us-east-1"

--- a/fastly/fastly.go
+++ b/fastly/fastly.go
@@ -174,7 +174,7 @@ func fatalIfErr(log *logrus.Logger, err error) {
 }
 
 func getFastlyStats(log *logrus.Logger, config Config) FastlyRealTimeDataV1 {
-	fastlyStats := fmt.Sprintf("%vchannel/%v/ts/0", FastlyStatsEndpoint, config.ServiceID)
+	fastlyStats := fmt.Sprintf("%vchannel/%v/ts/h", FastlyStatsEndpoint, config.ServiceID)
 	httpReq, err := http.NewRequest("GET", fastlyStats, bytes.NewBuffer([]byte("")))
 	httpReq.Header.Set("Fastly-Key", config.FastlyAPIKey)
 	httpReq.Header.Set("Content-Type", "application/json")

--- a/fastly/fastly_test.go
+++ b/fastly/fastly_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	fake "github.com/GannettDigital/paas-api-utils/utilsHTTP/fake"
-	"github.com/franela/goblin"
 	"github.com/Sirupsen/logrus"
+	"github.com/franela/goblin"
 )
 
 var fakeConfig Config
@@ -56,7 +56,7 @@ func TestGetFastlyStats(t *testing.T) {
 				ResultsList: []fake.Result{
 					{
 						Method: "GET",
-						URI:    "/v1/channel/1234/ts/0",
+						URI:    "/v1/channel/1234/ts/h",
 						Code:   200,
 						Data: []byte(`
 							{


### PR DESCRIPTION
## Ticket
https://jira.gannett.com/browse/PENG-3032

## Related PR
https://github.com/GannettDigital/paas-docker-base/pull/70

## Change Description
Switched the fastly endpoint to the History real time. This endpoint fetches data from the previous 120 seconds up to the latest timestamp for a channel.